### PR TITLE
Added support for specifying script source URL via preseed

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ switch to a shell terminal during installation, e.g.: `CTRL-F2`.
 $ sed -n 's#.*url=\([^ ]\+/\).*#\1#p' /proc/cmdline
 ```
 
+## Specifying script source location
+
+This can be specified on the kernel command line:
+
+``bash
+url=http://some.host/some.file``
+```
+
+Or alternatively you can use the preseed variable my-disk-prep/url
+
+```bash
+d-i my-disk-prep/url string http://some.host/some.file
+```
+
 ## Preseed configuration
 
 The disk-preparation `udeb` package can be downloaded and added from

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ $ sed -n 's#.*url=\([^ ]\+/\).*#\1#p' /proc/cmdline
 
 This can be specified on the kernel command line:
 
-``bash
-url=http://some.host/some.file``
+```bash
+url=http://some.host/some.file
 ```
 
 Or alternatively you can use the preseed variable my-disk-prep/url

--- a/debian/disk-preparation/DEBIAN/postinst
+++ b/debian/disk-preparation/DEBIAN/postinst
@@ -6,8 +6,16 @@ MYTAG="my-disk-prep"
 SCRIPT="disk-preparation"
 DLPATH="/tmp"
 
-DLURL=$( sed -n 's#.*url=\([^ ]\+/\).*#\1#p' /proc/cmdline )
-logger -t "$MYTAG" "DLURL extracted from /proc/cmdline: $DLURL"
+. /usr/share/debconf/confmodule
+db_get $MYTAG/url
+RC=$?
+if [ $RC -eq 0 ]; then
+    DLURL="$RET"
+    logger -t "$MYTAG" "DLURL from preseed $MYTAG/url: $DLURL"
+else
+    DLURL=$( sed -n 's#.*url=\([^ ]\+/\).*#\1#p' /proc/cmdline )
+    logger -t "$MYTAG" "DLURL extracted from /proc/cmdline: $DLURL"
+fi
 DLMETHOD=$( echo $DLURL | cut -d':' -f1 | tr 'a-z' 'A-Z' )
 logger -t "$MYTAG" "DLMETHOD extracted from \$DLURL: $DLMETHOD"
 if [ "x$DLMETHOD" = "xTFTP" ] ; then


### PR DESCRIPTION
I made a quick commit to add support for specifying the script source URL via a preseed variable. This makes it easier to set the URL when using Foreman.